### PR TITLE
Initialize prototype quoting API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Scopeio Prototype
+
+This repository contains a minimal prototype for a quoting tool.
+
+## Features
+- **Pricing Library** stored in `pricing.json`
+- **Quote Management** via HTTP endpoints
+  - `GET /pricing` – list pricing items
+  - `POST /quote` – create a quote with JSON payload `{ "customer": "name", "items": [...] }`
+  - `GET /quote/<id>` – retrieve a quote
+  - `POST /quote/<id>/send` – mark a quote as sent
+  - `GET /quotes` – list all quotes
+
+Quotes are stored in `quotes.json` and their status is tracked (draft/sent).
+
+## Running
+```
+python server.py
+```
+
+## Testing
+```
+python -m unittest discover -s tests
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scopeio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.py",
+  "scripts": {
+    "start": "python server.py",
+    "test": "python -m unittest discover -s tests"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/pricing.json
+++ b/pricing.json
@@ -1,0 +1,5 @@
+[
+    {"id": 1, "name": "Roof Replacement", "price": 10000},
+    {"id": 2, "name": "Window Installation", "price": 500},
+    {"id": 3, "name": "Siding Repair", "price": 2000}
+]

--- a/quotes.json
+++ b/quotes.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "customer": "Jane",
+    "items": [],
+    "status": "sent"
+  }
+]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,101 @@
+import json
+import os
+from urllib.parse import parse_qs
+from wsgiref.simple_server import make_server
+
+PRICING_FILE = 'pricing.json'
+QUOTES_FILE = 'quotes.json'
+
+
+def load_pricing():
+    with open(PRICING_FILE, 'r') as f:
+        return json.load(f)
+
+
+def load_quotes():
+    if not os.path.exists(QUOTES_FILE):
+        return []
+    with open(QUOTES_FILE, 'r') as f:
+        return json.load(f)
+
+
+def save_quotes(quotes):
+    with open(QUOTES_FILE, 'w') as f:
+        json.dump(quotes, f, indent=2)
+
+
+def create_quote(data):
+    quotes = load_quotes()
+    quote_id = len(quotes) + 1
+    quote = {
+        'id': quote_id,
+        'customer': data.get('customer', 'Unknown'),
+        'items': data.get('items', []),
+        'status': 'draft'
+    }
+    quotes.append(quote)
+    save_quotes(quotes)
+    return quote
+
+
+def update_quote_status(quote_id, status):
+    quotes = load_quotes()
+    for q in quotes:
+        if q['id'] == quote_id:
+            q['status'] = status
+            save_quotes(quotes)
+            return q
+    return None
+
+
+def application(environ, start_response):
+    path = environ.get('PATH_INFO', '')
+    method = environ.get('REQUEST_METHOD', 'GET')
+    if path == '/pricing' and method == 'GET':
+        data = json.dumps(load_pricing()).encode()
+        start_response('200 OK', [('Content-Type', 'application/json')])
+        return [data]
+    elif path == '/quote' and method == 'POST':
+        try:
+            size = int(environ.get('CONTENT_LENGTH', 0))
+        except (ValueError, TypeError):
+            size = 0
+        body = environ['wsgi.input'].read(size)
+        data = json.loads(body.decode() or '{}')
+        quote = create_quote(data)
+        start_response('201 Created', [('Content-Type', 'application/json')])
+        return [json.dumps(quote).encode()]
+    elif path.startswith('/quote/') and method == 'GET':
+        quote_id = int(path.split('/')[-1])
+        quotes = load_quotes()
+        for q in quotes:
+            if q['id'] == quote_id:
+                start_response('200 OK', [('Content-Type', 'application/json')])
+                return [json.dumps(q).encode()]
+        start_response('404 Not Found', [('Content-Type', 'application/json')])
+        return [json.dumps({'error': 'Quote not found'}).encode()]
+    elif path.startswith('/quote/') and path.endswith('/send') and method == 'POST':
+        quote_id = int(path.split('/')[2])
+        quote = update_quote_status(quote_id, 'sent')
+        if quote:
+            start_response('200 OK', [('Content-Type', 'application/json')])
+            return [json.dumps(quote).encode()]
+        else:
+            start_response('404 Not Found', [('Content-Type', 'application/json')])
+            return [json.dumps({'error': 'Quote not found'}).encode()]
+    elif path == '/quotes' and method == 'GET':
+        start_response('200 OK', [('Content-Type', 'application/json')])
+        return [json.dumps(load_quotes()).encode()]
+    else:
+        start_response('404 Not Found', [('Content-Type', 'text/plain')])
+        return [b'Not Found']
+
+
+def run_server(host='0.0.0.0', port=8000):
+    with make_server(host, port, application) as httpd:
+        print(f"Serving on {host}:{port}...")
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run_server()

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -1,0 +1,28 @@
+import os
+import server
+import unittest
+
+class QuoteTests(unittest.TestCase):
+    def setUp(self):
+        if os.path.exists(server.QUOTES_FILE):
+            os.remove(server.QUOTES_FILE)
+
+    def test_create_quote(self):
+        data = {'customer': 'John Doe', 'items': [{'id': 1, 'quantity': 2}]}
+        quote = server.create_quote(data)
+        self.assertEqual(quote['id'], 1)
+        self.assertEqual(quote['status'], 'draft')
+        quotes = server.load_quotes()
+        self.assertEqual(len(quotes), 1)
+        self.assertEqual(quotes[0]['customer'], 'John Doe')
+
+    def test_update_quote_status(self):
+        data = {'customer': 'Jane', 'items': []}
+        quote = server.create_quote(data)
+        updated = server.update_quote_status(quote['id'], 'sent')
+        self.assertEqual(updated['status'], 'sent')
+        quotes = server.load_quotes()
+        self.assertEqual(quotes[0]['status'], 'sent')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add minimal Python server using only stdlib
- store pricing items and quotes as JSON
- implement quote creation and status updates
- provide unit tests for quote logic

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68422a21f198832192694c93d52cee52